### PR TITLE
Update client.rb

### DIFF
--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -123,7 +123,7 @@ require 'rex/proto/smb/exceptions'
       smb.login('*SMBSERVER', self.options['smb_user'], self.options['smb_pass'])
       smb.connect("\\\\#{self.handle.address}\\IPC$")
       self.smb = smb
-      self.smb.read_timeout = self.options['read_timeout']
+      self.smb.client.read_timeout = self.options['read_timeout']
     end
 
     f = self.smb.create_pipe(self.handle.options[0])


### PR DESCRIPTION
Line 126 references the instance variable self.smb.read_timeout. SMB is an instance of simpleclient (Lines 118 || 120) and does not have an instance variable by that name. Client, which is an instance variable of a simpleclient object, does. I updated this line to access the client instance variable. Testing this appears to work as intended.