### PR TITLE
Fix Issue #7

### DIFF
--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -79,26 +79,7 @@ begin
     end
 
     # Raise an error if no selected versions are supported
-    ssl_ctx_method = [:SSLv23,
-      :SSLv23_client,
-      :SSLv23_server,
-      :SSLv2,
-      :SSLv2_client,
-      :SSLv2_server,
-      :SSLv3,
-      :SSLv3_client,
-      :SSLv3_server,
-      :TLSv1,
-      :TLSv1_client,
-      :TLSv1_server,
-      :TLSv1_1,
-      :TLSv1_1_client,
-      :TLSv1_1_server,
-      :TLSv1_2,
-      :TLSv1_2_client,
-      :TLSv1_2_server
-    ]
-    if ! ssl_ctx_method.include? version version
+    if ! ssl_versions.include? version
       raise ArgumentError, 'The system OpenSSL does not support the requested SSL/TLS version'
     end
 
@@ -108,6 +89,20 @@ begin
 
     # Track the SSL version
     self.ssl_negotiated_version = version
+  end
+
+
+  # List of available SSL versions
+  #
+  # Fix for:
+  #   rex/socket/ssl_tcp.rb:82: warning: constant OpenSSL::SSL::SSLContext::METHODS is deprecated
+  def ssl_versions
+    ssl_context = OpenSSL::SSL::SSLContext
+    if ssl_context.const_defined?(:METHODS_MAP)
+      ssl_context.const_get(:METHODS_MAP).keys
+    else
+      ssl_context::METHODS.reject { |method| method.match(/server|client/) }
+    end.sort.reverse
   end
 
   def initsock_with_ssl_version(params, version)
@@ -385,4 +380,3 @@ rescue LoadError
 end
 
 end
-

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -79,7 +79,26 @@ begin
     end
 
     # Raise an error if no selected versions are supported
-    if ! OpenSSL::SSL::SSLContext.methods.include? version
+    ssl_ctx_method = [:SSLv23,
+      :SSLv23_client,
+      :SSLv23_server,
+      :SSLv2,
+      :SSLv2_client,
+      :SSLv2_server,
+      :SSLv3,
+      :SSLv3_client,
+      :SSLv3_server,
+      :TLSv1,
+      :TLSv1_client,
+      :TLSv1_server,
+      :TLSv1_1,
+      :TLSv1_1_client,
+      :TLSv1_1_server,
+      :TLSv1_2,
+      :TLSv1_2_client,
+      :TLSv1_2_server
+    ]
+    if ! ssl_ctx_method.include? version version
       raise ArgumentError, 'The system OpenSSL does not support the requested SSL/TLS version'
     end
 

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -79,7 +79,7 @@ begin
     end
 
     # Raise an error if no selected versions are supported
-    if ! OpenSSL::SSL::SSLContext::METHODS.include? version
+    if ! OpenSSL::SSL::SSLContext.methods.include? version
       raise ArgumentError, 'The system OpenSSL does not support the requested SSL/TLS version'
     end
 


### PR DESCRIPTION
Fix issue #7  
```
/var/lib/gems/2.5.0/gems/rex-2.0.12/lib/rex/socket/ssl_tcp.rb:82: warning: constant OpenSSL::SSL::SSLContext::METHODS is deprecated
```